### PR TITLE
Fix fade animation handling

### DIFF
--- a/app/manage-clients.tsx
+++ b/app/manage-clients.tsx
@@ -32,7 +32,7 @@ export default function ManageClientsScreen() {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const router = useRouter();
-  const fadeAnims = useState(clients.map(() => new Animated.Value(0)))[0];
+  const [fadeAnims, setFadeAnims] = useState<Animated.Value[]>([]);
 
   // Load user_id
   useEffect(() => {
@@ -63,14 +63,7 @@ export default function ManageClientsScreen() {
       const data = await res.json();
       if (Array.isArray(data)) {
         setClients(data);
-        // Initialize animations
-        fadeAnims.forEach((anim) => {
-          Animated.timing(anim, {
-            toValue: 1,
-            duration: 600,
-            useNativeDriver: true,
-          }).start();
-        });
+        setFadeAnims(data.map(() => new Animated.Value(0)));
       } else {
         throw new Error("Invalid response");
       }
@@ -82,6 +75,16 @@ export default function ManageClientsScreen() {
       setRefreshing(false);
     }
   };
+
+  useEffect(() => {
+    fadeAnims.forEach((anim) => {
+      Animated.timing(anim, {
+        toValue: 1,
+        duration: 600,
+        useNativeDriver: true,
+      }).start();
+    });
+  }, [fadeAnims]);
 
   const handleDelete = (clientId) => {
     Alert.alert(

--- a/app/view-invoices.tsx
+++ b/app/view-invoices.tsx
@@ -25,7 +25,7 @@ export default function ManageInvoicesScreen() {
   const [invoices, setInvoices] = useState([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
-  const fadeAnims = useState(invoices.map(() => new Animated.Value(0)))[0];
+  const [fadeAnims, setFadeAnims] = useState<Animated.Value[]>([]);
 
   // Load user_id
   useEffect(() => {
@@ -64,14 +64,7 @@ export default function ManageInvoicesScreen() {
       const data = await res.json();
       if (Array.isArray(data)) {
         setInvoices(data);
-        // Initialize fade animations
-        fadeAnims.forEach((anim) => {
-          Animated.timing(anim, {
-            toValue: 1,
-            duration: 600,
-            useNativeDriver: true,
-          }).start();
-        });
+        setFadeAnims(data.map(() => new Animated.Value(0)));
       } else {
         throw new Error("Invalid response format");
       }
@@ -83,6 +76,16 @@ export default function ManageInvoicesScreen() {
       setRefreshing(false);
     }
   };
+
+  useEffect(() => {
+    fadeAnims.forEach((anim) => {
+      Animated.timing(anim, {
+        toValue: 1,
+        duration: 600,
+        useNativeDriver: true,
+      }).start();
+    });
+  }, [fadeAnims]);
 
   // Render invoice card
   const renderInvoice = ({ item, index }) => (

--- a/app/view-payment.tsx
+++ b/app/view-payment.tsx
@@ -31,7 +31,7 @@ export default function PaymentPageScreen() {
   const [payments, setPayments] = useState([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
-  const fadeAnims = useState(payments.map(() => new Animated.Value(0)))[0];
+  const [fadeAnims, setFadeAnims] = useState<Animated.Value[]>([]);
 
   // Load user_id
   useEffect(() => {
@@ -67,14 +67,7 @@ export default function PaymentPageScreen() {
       const data = await res.json();
       if (Array.isArray(data)) {
         setPayments(data);
-        // Initialize fade animations
-        fadeAnims.forEach((anim) => {
-          Animated.timing(anim, {
-            toValue: 1,
-            duration: 600,
-            useNativeDriver: true,
-          }).start();
-        });
+        setFadeAnims(data.map(() => new Animated.Value(0)));
       } else {
         throw new Error("Invalid response format");
       }
@@ -86,6 +79,16 @@ export default function PaymentPageScreen() {
       setRefreshing(false);
     }
   };
+
+  useEffect(() => {
+    fadeAnims.forEach((anim) => {
+      Animated.timing(anim, {
+        toValue: 1,
+        duration: 600,
+        useNativeDriver: true,
+      }).start();
+    });
+  }, [fadeAnims]);
 
   // Render payment card
   const renderPayment = ({ item, index }) => (


### PR DESCRIPTION
## Summary
- refresh animations when invoices, clients, or payments change

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ced98fbd883249910ea9a728650bf