### PR TITLE
Fix edit screen animations

### DIFF
--- a/app/create-invoice.tsx
+++ b/app/create-invoice.tsx
@@ -53,6 +53,7 @@ export default function CreateInvoiceScreen() {
   });
   const [loading, setLoading] = useState(false);
   const [fadeAnim] = useState(new Animated.Value(0));
+  const [itemFadeAnims, setItemFadeAnims] = useState<Animated.Value[]>([]);
 
   // Load user_id, clients, and generate invoice number
   useEffect(() => {
@@ -119,6 +120,21 @@ export default function CreateInvoiceScreen() {
   const handleRemoveItem = (idx) => {
     setItems(items.filter((_, i) => i !== idx));
   };
+
+  // Refresh item fade animations whenever item count changes
+  useEffect(() => {
+    setItemFadeAnims(items.map(() => new Animated.Value(0)));
+  }, [items.length]);
+
+  useEffect(() => {
+    itemFadeAnims.forEach((anim) => {
+      Animated.timing(anim, {
+        toValue: 1,
+        duration: 600,
+        useNativeDriver: true,
+      }).start();
+    });
+  }, [itemFadeAnims]);
 
   // Handle new item input changes
   const handleChangeNewItem = (key, value) => {
@@ -282,7 +298,10 @@ export default function CreateInvoiceScreen() {
           <Text style={styles.emptyText}>No items added. Add an item below.</Text>
         ) : (
           items.map((item, idx) => (
-            <Animated.View key={idx} style={[styles.itemCard, { opacity: fadeAnim }]}>
+            <Animated.View
+              key={idx}
+              style={[styles.itemCard, { opacity: itemFadeAnims[idx] || 1 }]}
+            >
               <View style={styles.itemRow}>
                 <Ionicons name="cube-outline" size={24} color="#8b5cf6" style={styles.icon} />
                 <Text style={styles.itemText}>{item.description}</Text>

--- a/app/edit-invoice.tsx
+++ b/app/edit-invoice.tsx
@@ -15,6 +15,7 @@ import {
   TextInput,
   TouchableOpacity,
   View,
+  Animated,
 } from "react-native";
 
 export default function EditInvoiceScreen() {
@@ -36,6 +37,7 @@ export default function EditInvoiceScreen() {
     },
   ]);
   const [loading, setLoading] = useState(true);
+  const [itemFadeAnims, setItemFadeAnims] = useState<Animated.Value[]>([]);
   const { invoice_id } = useLocalSearchParams();
   const router = useRouter();
 
@@ -135,6 +137,21 @@ export default function EditInvoiceScreen() {
     setItems(items.filter((_, i) => i !== idx));
   };
 
+  // Refresh item animations whenever item count changes
+  useEffect(() => {
+    setItemFadeAnims(items.map(() => new Animated.Value(0)));
+  }, [items.length]);
+
+  useEffect(() => {
+    itemFadeAnims.forEach((anim) => {
+      Animated.timing(anim, {
+        toValue: 1,
+        duration: 600,
+        useNativeDriver: true,
+      }).start();
+    });
+  }, [itemFadeAnims]);
+
   const handleChangeItem = (idx, key, value) => {
     const newItems = [...items];
     newItems[idx][key] = value;
@@ -215,7 +232,7 @@ export default function EditInvoiceScreen() {
       behavior={Platform.OS === "ios" ? "padding" : undefined}
     >
       <ScrollView contentContainerStyle={styles.scroll}>
-        <Text style={styles.header}>Create Invoice</Text>
+        <Text style={styles.header}>Edit Invoice</Text>
         {/* CLIENT & INVOICE DETAILS */}
         <View style={styles.card}>
           <Text style={styles.label}>Client</Text>
@@ -301,7 +318,10 @@ export default function EditInvoiceScreen() {
           Invoice Items
         </Text>
         {items.map((item, idx) => (
-          <View key={idx} style={styles.itemCard}>
+          <Animated.View
+            key={idx}
+            style={[styles.itemCard, { opacity: itemFadeAnims[idx] || 1 }]}
+          >
             <View style={styles.itemRow}>
               <TextInput
                 style={[styles.input, { flex: 2 }]}
@@ -358,7 +378,7 @@ export default function EditInvoiceScreen() {
                 onChangeText={(val) => handleChangeItem(idx, "tax_percent", val)}
               />
             </View>
-          </View>
+          </Animated.View>
         ))}
 
         <TouchableOpacity style={styles.addBtn} onPress={handleAddItem}>
@@ -394,7 +414,7 @@ export default function EditInvoiceScreen() {
           {loading ? (
             <ActivityIndicator color="#fff" />
           ) : (
-            <Text style={styles.submitBtnText}>Create Invoice</Text>
+            <Text style={styles.submitBtnText}>Update Invoice</Text>
           )}
         </TouchableOpacity>
       </ScrollView>
@@ -533,3 +553,4 @@ const styles = StyleSheet.create({
     letterSpacing: 0.2,
   },
 });
+

--- a/app/manage-clients.tsx
+++ b/app/manage-clients.tsx
@@ -32,7 +32,7 @@ export default function ManageClientsScreen() {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const router = useRouter();
-  const fadeAnims = useState(clients.map(() => new Animated.Value(0)))[0];
+  const [fadeAnims, setFadeAnims] = useState<Animated.Value[]>([]);
 
   // Load user_id
   useEffect(() => {
@@ -63,14 +63,7 @@ export default function ManageClientsScreen() {
       const data = await res.json();
       if (Array.isArray(data)) {
         setClients(data);
-        // Initialize animations
-        fadeAnims.forEach((anim) => {
-          Animated.timing(anim, {
-            toValue: 1,
-            duration: 600,
-            useNativeDriver: true,
-          }).start();
-        });
+        setFadeAnims(data.map(() => new Animated.Value(0)));
       } else {
         throw new Error("Invalid response");
       }
@@ -82,6 +75,16 @@ export default function ManageClientsScreen() {
       setRefreshing(false);
     }
   };
+
+  useEffect(() => {
+    fadeAnims.forEach((anim) => {
+      Animated.timing(anim, {
+        toValue: 1,
+        duration: 600,
+        useNativeDriver: true,
+      }).start();
+    });
+  }, [fadeAnims]);
 
   const handleDelete = (clientId) => {
     Alert.alert(

--- a/app/view-invoices.tsx
+++ b/app/view-invoices.tsx
@@ -25,7 +25,7 @@ export default function ManageInvoicesScreen() {
   const [invoices, setInvoices] = useState([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
-  const fadeAnims = useState(invoices.map(() => new Animated.Value(0)))[0];
+  const [fadeAnims, setFadeAnims] = useState<Animated.Value[]>([]);
 
   // Load user_id
   useEffect(() => {
@@ -64,14 +64,7 @@ export default function ManageInvoicesScreen() {
       const data = await res.json();
       if (Array.isArray(data)) {
         setInvoices(data);
-        // Initialize fade animations
-        fadeAnims.forEach((anim) => {
-          Animated.timing(anim, {
-            toValue: 1,
-            duration: 600,
-            useNativeDriver: true,
-          }).start();
-        });
+        setFadeAnims(data.map(() => new Animated.Value(0)));
       } else {
         throw new Error("Invalid response format");
       }
@@ -83,6 +76,16 @@ export default function ManageInvoicesScreen() {
       setRefreshing(false);
     }
   };
+
+  useEffect(() => {
+    fadeAnims.forEach((anim) => {
+      Animated.timing(anim, {
+        toValue: 1,
+        duration: 600,
+        useNativeDriver: true,
+      }).start();
+    });
+  }, [fadeAnims]);
 
   // Render invoice card
   const renderInvoice = ({ item, index }) => (

--- a/app/view-payment.tsx
+++ b/app/view-payment.tsx
@@ -31,7 +31,7 @@ export default function PaymentPageScreen() {
   const [payments, setPayments] = useState([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
-  const fadeAnims = useState(payments.map(() => new Animated.Value(0)))[0];
+  const [fadeAnims, setFadeAnims] = useState<Animated.Value[]>([]);
 
   // Load user_id
   useEffect(() => {
@@ -67,14 +67,7 @@ export default function PaymentPageScreen() {
       const data = await res.json();
       if (Array.isArray(data)) {
         setPayments(data);
-        // Initialize fade animations
-        fadeAnims.forEach((anim) => {
-          Animated.timing(anim, {
-            toValue: 1,
-            duration: 600,
-            useNativeDriver: true,
-          }).start();
-        });
+        setFadeAnims(data.map(() => new Animated.Value(0)));
       } else {
         throw new Error("Invalid response format");
       }
@@ -86,6 +79,16 @@ export default function PaymentPageScreen() {
       setRefreshing(false);
     }
   };
+
+  useEffect(() => {
+    fadeAnims.forEach((anim) => {
+      Animated.timing(anim, {
+        toValue: 1,
+        duration: 600,
+        useNativeDriver: true,
+      }).start();
+    });
+  }, [fadeAnims]);
 
   // Render payment card
   const renderPayment = ({ item, index }) => (


### PR DESCRIPTION
## Summary
- refresh item fade animations only when item count changes
- same adjustment for Edit Invoice screen

## Testing
- `npm run lint` *(fails: expo not found)*
- `npx tsc -p tsconfig.json` *(fails: missing modules and tsconfig references)*

------
https://chatgpt.com/codex/tasks/task_e_685ced98fbd883249910ea9a728650bf