### PR TITLE
UI tweaks with SafeArea and progress bar

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,11 +2,16 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Stack, useRouter } from "expo-router";
 import React, { useEffect, useState } from "react";
 import { ActivityIndicator, StyleSheet, View } from "react-native";
+import { SafeAreaProvider } from "react-native-safe-area-context";
+import { useFonts } from "expo-font";
 
 export default function RootLayout() {
   const [isLoading, setIsLoading] = useState(true);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const router = useRouter();
+  const [fontsLoaded] = useFonts({
+    SpaceMono: require("../assets/fonts/SpaceMono-Regular.ttf"),
+  });
 
   // Check login status on mount
   useEffect(() => {
@@ -32,8 +37,8 @@ export default function RootLayout() {
     }
   }, [isLoading, isLoggedIn]);
 
-  // Show loading screen while checking
-  if (isLoading) {
+  // Show loading screen while checking or while fonts load
+  if (isLoading || !fontsLoaded) {
     return (
       <View style={styles.loadingContainer}>
         <ActivityIndicator size="large" color="#38bdf8" />
@@ -42,14 +47,16 @@ export default function RootLayout() {
   }
 
   return (
-    <Stack screenOptions={{ headerShown: false }}>
+    <SafeAreaProvider>
+      <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="login" options={{ headerShown: false }} />
       <Stack.Screen name="signup" options={{ headerShown: false }} />
       <Stack.Screen name="dashboard" options={{ headerShown: false }} />
       <Stack.Screen name="manage-invoices" options={{ headerShown: false }} />
       <Stack.Screen name="create-invoice" options={{ headerShown: false }} />
       <Stack.Screen name="dues-report" options={{ headerShown: false }} />
-    </Stack>
+      </Stack>
+    </SafeAreaProvider>
   );
 }
 

--- a/app/create-invoice.tsx
+++ b/app/create-invoice.tsx
@@ -16,6 +16,8 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { fonts } from "./theme";
 
 // Utility function for date formatting (YYYY-MM-DD)
 const formatDate = (date) => {
@@ -202,10 +204,11 @@ export default function CreateInvoiceScreen() {
   const totals = getTotals();
 
   return (
-    <KeyboardAvoidingView
-      style={styles.container}
-      behavior={Platform.OS === "ios" ? "padding" : undefined}
-    >
+    <SafeAreaView style={styles.safeArea}>
+      <KeyboardAvoidingView
+        style={styles.container}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+      >
       <ScrollView contentContainerStyle={styles.scroll}>
         {/* Header */}
         <Text style={styles.header}>Create New Invoice</Text>
@@ -401,12 +404,17 @@ export default function CreateInvoiceScreen() {
           </TouchableOpacity>
         </Animated.View>
       </ScrollView>
-    </KeyboardAvoidingView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
+    flex: 1,
+    backgroundColor: "#0f172a",
+  },
+  safeArea: {
     flex: 1,
     backgroundColor: "#0f172a",
   },
@@ -420,6 +428,7 @@ const styles = StyleSheet.create({
     fontSize: 32,
     fontWeight: "700",
     color: "#f8fafc",
+    fontFamily: fonts.mono,
     marginBottom: 20,
     textAlign: "center",
     letterSpacing: 1,

--- a/app/dashboard.tsx
+++ b/app/dashboard.tsx
@@ -8,13 +8,14 @@ import {
   Alert,
   Animated,
   RefreshControl,
-  SafeAreaView,
   ScrollView,
   StyleSheet,
   Text,
   TouchableOpacity,
   View,
 } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { fonts } from "./theme";
 
 const USER_STORAGE_KEY = "@invoiceApp:user";
 
@@ -209,9 +210,31 @@ export default function DashboardScreen() {
                 />
                 <Text style={styles.statValue}>₹{dashboard.unpaid_amount}</Text>
                 <Text style={styles.statLabel}>Unpaid Amount</Text>
-              </LinearGradient>
-            </Animated.View>
-          )}
+          </LinearGradient>
+        </Animated.View>
+      )}
+
+      {dashboard && (
+        <View style={styles.progressWrapper}>
+          <View style={styles.progressTrack}>
+            <View
+              style={[
+                styles.progressFill,
+                {
+                  width: `${
+                    (dashboard.paid_invoices /
+                      Math.max(dashboard.total_invoices, 1)) *
+                    100
+                  }%`,
+                },
+              ]}
+            />
+          </View>
+          <Text style={styles.progressText}>
+            {dashboard.paid_invoices}/{dashboard.total_invoices} invoices paid
+          </Text>
+        </View>
+      )}
 
           {/* Actions */}
           <Animated.View style={[styles.actionsContainer, { opacity: fadeAnim }]}>
@@ -266,6 +289,7 @@ const styles = StyleSheet.create({
     fontSize: 24,
     fontWeight: "700",
     color: "#facc15",
+    fontFamily: fonts.mono,
   },
   logoutButton: {
     padding: 8,
@@ -301,6 +325,25 @@ const styles = StyleSheet.create({
   statLabel: {
     fontSize: 14,
     color: "#9ca3af",
+  },
+  progressWrapper: {
+    marginBottom: 24,
+  },
+  progressTrack: {
+    height: 8,
+    backgroundColor: "#2a2e36",
+    borderRadius: 4,
+    overflow: "hidden",
+  },
+  progressFill: {
+    height: 8,
+    backgroundColor: "#22c55e",
+  },
+  progressText: {
+    marginTop: 8,
+    color: "#9ca3af",
+    fontSize: 14,
+    textAlign: "center",
   },
   actionsContainer: {
     flexDirection: "row",

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -16,6 +16,8 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { fonts } from "./theme";
 
 const { width } = Dimensions.get("window");
 
@@ -77,11 +79,12 @@ export default function LoginScreen() {
 
   return (
     <LinearGradient colors={["#18181b", "#23272f"]} style={styles.container}>
-      <KeyboardAvoidingView
-        behavior={Platform.OS === "ios" ? "padding" : "height"}
-        style={styles.keyboardView}
-      >
-        <Animated.View style={[styles.card, { opacity: fadeAnim, transform: [{ translateY: cardAnim }] }]}>
+      <SafeAreaView style={styles.safeArea}>
+        <KeyboardAvoidingView
+          behavior={Platform.OS === "ios" ? "padding" : "height"}
+          style={styles.keyboardView}
+        >
+          <Animated.View style={[styles.card, { opacity: fadeAnim, transform: [{ translateY: cardAnim }] }]}>
           {/* Branding */}
           <View style={styles.brandContainer}>
             <Ionicons name="leaf-outline" size={40} color="#38bdf8" />
@@ -150,7 +153,8 @@ export default function LoginScreen() {
             </Link>
           </View>
         </Animated.View>
-      </KeyboardAvoidingView>
+        </KeyboardAvoidingView>
+      </SafeAreaView>
     </LinearGradient>
   );
 }
@@ -160,6 +164,9 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: "center",
     alignItems: "center",
+  },
+  safeArea: {
+    flex: 1,
   },
   keyboardView: {
     flex: 1,
@@ -189,6 +196,7 @@ const styles = StyleSheet.create({
     fontSize: 28,
     fontWeight: "700",
     color: "#facc15",
+    fontFamily: fonts.mono,
     marginTop: 8,
   },
   tagline: {
@@ -240,6 +248,7 @@ const styles = StyleSheet.create({
     color: "#fff",
     fontSize: 18,
     fontWeight: "600",
+    fontFamily: fonts.mono,
   },
   footer: {
     flexDirection: "row",

--- a/app/signup.tsx
+++ b/app/signup.tsx
@@ -15,6 +15,8 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { fonts } from "./theme";
 
 const { width } = Dimensions.get("window");
 
@@ -90,11 +92,12 @@ export default function SignupScreen() {
 
   return (
     <LinearGradient colors={["#18181b", "#23272f"]} style={styles.container}>
-      <KeyboardAvoidingView
-        behavior={Platform.OS === "ios" ? "padding" : "height"}
-        style={styles.keyboardView}
-      >
-        <Animated.View style={[styles.card, { opacity: fadeAnim, transform: [{ translateY: cardAnim }] }]}>
+      <SafeAreaView style={styles.safeArea}>
+        <KeyboardAvoidingView
+          behavior={Platform.OS === "ios" ? "padding" : "height"}
+          style={styles.keyboardView}
+        >
+          <Animated.View style={[styles.card, { opacity: fadeAnim, transform: [{ translateY: cardAnim }] }]}>
           {/* Branding */}
           <View style={styles.brandContainer}>
             <Ionicons name="leaf-outline" size={40} color="#38bdf8" />
@@ -195,6 +198,7 @@ export default function SignupScreen() {
           </View>
         </Animated.View>
       </KeyboardAvoidingView>
+      </SafeAreaView>
     </LinearGradient>
   );
 }
@@ -204,6 +208,9 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: "center",
     alignItems: "center",
+  },
+  safeArea: {
+    flex: 1,
   },
   keyboardView: {
     flex: 1,
@@ -233,6 +240,7 @@ const styles = StyleSheet.create({
     fontSize: 28,
     fontWeight: "700",
     color: "#facc15",
+    fontFamily: fonts.mono,
     marginTop: 8,
   },
   tagline: {
@@ -275,6 +283,7 @@ const styles = StyleSheet.create({
     color: "#fff",
     fontSize: 18,
     fontWeight: "600",
+    fontFamily: fonts.mono,
   },
   footer: {
     flexDirection: "row",

--- a/app/theme.ts
+++ b/app/theme.ts
@@ -1,0 +1,13 @@
+export const colors = {
+  background: '#18181b',
+  surface: '#23272f',
+  primary: '#38bdf8',
+  secondary: '#facc15',
+  text: '#f8fafc',
+  muted: '#9ca3af',
+};
+
+export const fonts = {
+  regular: 'System',
+  mono: 'SpaceMono',
+};


### PR DESCRIPTION
## Summary
- load custom font and wrap app with SafeAreaProvider
- apply SafeAreaView to login, signup and create invoice screens
- add monospace font to headers and buttons
- add dashboard progress bar and minor styling
- create small theme file for colors and fonts

## Testing
- `npm run lint` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cfa5c67488324bdb27a9d90f4e1f7